### PR TITLE
Updated dependencies to latest compatible version 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "body-parser": "1.10.0",
-    "express": "4.10.6",
-    "lodash": "1.3",
-    "q": "2.0.1",
-    "serve-index": "1.5.3",
-    "serve-static": "1.7.1",
-    "simpleargs": "0.0.2"
+    "body-parser": "^1.10.0",
+    "express": "^4.10.6",
+    "lodash": "^1.3",
+    "q": "^2.0.1",
+    "serve-index": "^1.5.3",
+    "serve-static": "^1.7.1",
+    "simpleargs": "^0.0.2"
   },
   "bin": {
     "log-server": "bin/log-server.js"


### PR DESCRIPTION
This fixes a startup error with the q package. See the issue #1 for the output from the error.

The version of lodash also needs to be updated to 4.+, but that'll require some code changes since the `_.template` call works differently now.
